### PR TITLE
Add SnapAuth to auth flows

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+# vim:ft=sh
+VITE_SNAPAUTH_PUBLISHABLE_KEY=pubkey_d7c14c5cf55ddac9878179486c90ae7468b3f8bc

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+# vim:ft=sh
+VITE_SNAPAUTH_PUBLISHABLE_KEY=pubkey_f73c62d953397a45edbf1e6a7a1ce6dc41d69a31

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@blueprintjs/core": "^5.10.2",
+        "@snapauth/sdk": "^0.1.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1279,6 +1280,11 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@snapauth/sdk": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@snapauth/sdk/-/sdk-0.1.4.tgz",
+      "integrity": "sha512-WlMgsrhMDyU2C8gR5ycK8vhSj/Wy9viSQuI76Oi7dMlX1egrW3h7eAUV/yBqXZFVJ6qMeyahm++Y0Ba1VvNjXQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^5.10.2",
+    "@snapauth/sdk": "^0.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -4,38 +4,7 @@
   padding: 2rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+output pre {
+    text-wrap: wrap;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}

--- a/src/panels/Register.tsx
+++ b/src/panels/Register.tsx
@@ -1,18 +1,23 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { Button, FormGroup, InputGroup } from '@blueprintjs/core'
+
+import { SDK, RegisterResponse } from '@snapauth/sdk'
+
+const snapAuth = new SDK(import.meta.env.VITE_SNAPAUTH_PUBLISHABLE_KEY)
 
 const Register: React.FC = () => {
   const username = useRef<HTMLInputElement>(null)
-  const password = useRef<HTMLInputElement>(null)
 
-  const onSubmit = (e: React.FormEvent) => {
+  const [registerResponse, setRegisterResponse] = useState<RegisterResponse>()
+
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    alert(JSON.stringify({
-      username: username.current!.value,
-    }))
+
+    const registration = await snapAuth.startRegister({ name: username.current!.value })
+    setRegisterResponse(registration)
   }
 
-  return (
+  return <>
     <form onSubmit={onSubmit}>
       <FormGroup label="Create a username" labelInfo="(required)">
         <InputGroup
@@ -21,17 +26,12 @@ const Register: React.FC = () => {
           required
         />
       </FormGroup>
-      <FormGroup label="Create a password" labelInfo="(required)">
-        <InputGroup
-          autoComplete="new-password"
-          inputRef={password}
-          required
-          type="password"
-        />
-      </FormGroup>
       <Button type="submit" intent="primary">Register</Button>
     </form>
-  )
+    {registerResponse &&
+    <output><pre>{JSON.stringify(registerResponse, undefined, 2)}</pre></output>
+    }
+  </>
 }
 
 export default Register

--- a/src/panels/SignIn.tsx
+++ b/src/panels/SignIn.tsx
@@ -1,18 +1,23 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { Button, FormGroup, InputGroup } from '@blueprintjs/core'
+
+import { SDK, AuthResponse } from '@snapauth/sdk'
+
+const snapAuth = new SDK(import.meta.env.VITE_SNAPAUTH_PUBLISHABLE_KEY)
 
 const SignIn: React.FC = () => {
   const username = useRef<HTMLInputElement>(null)
-  const password = useRef<HTMLInputElement>(null)
 
-  const onSubmit = (e: React.FormEvent) => {
+  const [authResponse, setAuthResponse] = useState<AuthResponse>()
+
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    alert(JSON.stringify({
-      username: username.current!.value,
-    }))
+
+    const auth = await snapAuth.startAuth({ id: username.current!.value })
+    setAuthResponse(auth)
   }
 
-  return (
+  return <>
     <form onSubmit={onSubmit}>
       <FormGroup label="Your username" labelInfo="(required)">
         <InputGroup
@@ -21,17 +26,12 @@ const SignIn: React.FC = () => {
           required
         />
       </FormGroup>
-      <FormGroup label="Your password" labelInfo="(required)">
-        <InputGroup
-          autoComplete="current-password"
-          inputRef={password}
-          required
-          type="password"
-        />
-      </FormGroup>
       <Button type="submit" intent="primary">Sign In</Button>
     </form>
-  )
+    {authResponse &&
+    <output><pre>{JSON.stringify(authResponse, undefined, 2)}</pre></output>
+    }
+    </>
 }
 
 export default SignIn


### PR DESCRIPTION
This adds the SnapAuth SDK and calls it during the onSubmit handlers for the register and sign in forms.