### PR TITLE
Add a simulated backend to demonstrate the end-to-end integration process

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,8 @@
 # vim:ft=sh
-VITE_SNAPAUTH_PUBLISHABLE_KEY=pubkey_d7c14c5cf55ddac9878179486c90ae7468b3f8bc
+VITE_SNAPAUTH_PUBLISHABLE_KEY=pubkey_49b5a97eea59f1b347a3099827088acaba009562
+
+#
+# NEVER, EVER publish your SnapAuth secret key like this.
+# We have a special one just for this demo site.
+#
+VITE_SNAPAUTH_SECRET_KEY_NEVER_PUBLISH_THIS_IN_A_REAL_APP=secret_fa9159e9de303b2fcc36acea97a4144dfdc91433_3c6131a958d39eb1808bf2006c3befd44d6fa786

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,8 @@
 # vim:ft=sh
 VITE_SNAPAUTH_PUBLISHABLE_KEY=pubkey_f73c62d953397a45edbf1e6a7a1ce6dc41d69a31
+
+#
+# NEVER, EVER publish your SnapAuth secret key like this.
+# We have a special one just for this demo site.
+#
+VITE_SNAPAUTH_SECRET_KEY_NEVER_PUBLISH_THIS_IN_A_REAL_APP=secret_885706227ca1edcb8de96baabb722752d2eb6946_e430fb30d66a04eb36ae30f32148f5cf83947830

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 # vim:ft=sh
-VITE_SNAPAUTH_PUBLISHABLE_KEY=pubkey_f73c62d953397a45edbf1e6a7a1ce6dc41d69a31
+VITE_SNAPAUTH_PUBLISHABLE_KEY=pubkey_aeaf8cebcff85e287e1b50e8ecc3670e1133a93c
 
 #
 # NEVER, EVER publish your SnapAuth secret key like this.

--- a/src/components/ApiData.tsx
+++ b/src/components/ApiData.tsx
@@ -1,0 +1,32 @@
+import { Code, Section, SectionCard } from '@blueprintjs/core'
+import { AuthResponse, RegisterResponse } from '@snapauth/sdk'
+
+import type { ApiInfo } from 'helpers/backend'
+
+interface Props {
+  backendData: ApiInfo|undefined
+  clientResponse: AuthResponse|RegisterResponse|undefined
+}
+
+const ApiData: React.FC<Props> = ({ backendData, clientResponse }) => {
+  return <>
+    {clientResponse && <Section title="Client SDK Response">
+      <output>
+        <pre>{JSON.stringify(clientResponse, undefined, 2)}</pre>
+      </output>
+    </Section>}
+    {backendData && <Section title="Backend">
+      <SectionCard>
+        <p><Code>POST /registration/attach</Code></p>
+        <output><pre>{JSON.stringify(backendData.requestBody, undefined, 2)}</pre></output>
+      </SectionCard>
+
+      <SectionCard>
+        <p>Response</p>
+        <output><pre>{JSON.stringify(backendData.responseBody, undefined, 2)}</pre></output>
+      </SectionCard>
+    </Section>}
+  </>
+}
+
+export default ApiData

--- a/src/components/ApiData.tsx
+++ b/src/components/ApiData.tsx
@@ -1,4 +1,4 @@
-import { Code, Section, SectionCard } from '@blueprintjs/core'
+import { Section, SectionCard } from '@blueprintjs/core'
 import { AuthResponse, RegisterResponse } from '@snapauth/sdk'
 
 import type { ApiInfo } from 'helpers/backend'
@@ -17,7 +17,7 @@ const ApiData: React.FC<Props> = ({ backendData, clientResponse }) => {
     </Section>}
     {backendData && <Section title="Backend">
       <SectionCard>
-        <p><Code>POST /registration/attach</Code></p>
+        <p>Request</p>
         <output><pre>{JSON.stringify(backendData.requestBody, undefined, 2)}</pre></output>
       </SectionCard>
 

--- a/src/components/ApiData.tsx
+++ b/src/components/ApiData.tsx
@@ -11,9 +11,11 @@ interface Props {
 const ApiData: React.FC<Props> = ({ backendData, clientResponse }) => {
   return <>
     {clientResponse && <Section title="Client SDK Response">
-      <output>
-        <pre>{JSON.stringify(clientResponse, undefined, 2)}</pre>
-      </output>
+      <SectionCard>
+        <output>
+          <pre>{JSON.stringify(clientResponse, undefined, 2)}</pre>
+        </output>
+      </SectionCard>
     </Section>}
     {backendData && <Section title="Backend">
       <SectionCard>

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,1 +1,2 @@
+export { default as ApiData } from './ApiData'
 export { default as SourceUrl } from './SourceUrl'

--- a/src/helpers/backend.ts
+++ b/src/helpers/backend.ts
@@ -1,16 +1,15 @@
-
-
-// This is copy-pasted from the Node SDK, and slightly tweaked to run
-// in-browser.
-
-// Do NOT do this in a real application!
-
-// Normally, you would send the client token to YOUR backend, and use one of
-// our server SDKs to attach or verify it.
-//
-// Since this demo doesn't have a backend, it's directly returning what the
-// SnapAuth API returned so it can be displayed.
-
+/**
+ * DO NOT MAKE SNAPAUTH SERVER CALLS FROM THE CLIENT IN A REAL APPLICATION!
+ *
+ * This will leak your API secret, which can easily lead to widespread account
+ * takeovers.
+ *
+ * Instead, you would send the client token to YOUR backend, and use one of
+ * our server SDKs to attach or verify it.
+ *
+ * Since this demo doesn't have a backend, it's directly returning what the
+ * SnapAuth API returned so it can be displayed.
+ */
 class FakeBackendApi {
 
   private authHeader: string
@@ -25,8 +24,8 @@ class FakeBackendApi {
   // and no handle. Normally, the `id` would be a generated value (primary
   // key, etc) and the `handle` would be a username, email address, or
   // similar user-provided identifier.
-  attachRegistration = async (token: string, userId: string): Promise<ApiInfo> => {
-    return await this.post('/registration/attach', { token, user: { id: userId } })
+  register = async (token: string, username: string): Promise<ApiInfo> => {
+    return await this.post('/registration/attach', { token, user: { id: username } })
   }
 
   signIn = async (token: string): Promise<ApiInfo> => {

--- a/src/helpers/backend.ts
+++ b/src/helpers/backend.ts
@@ -1,0 +1,70 @@
+
+
+// This is copy-pasted from the Node SDK, and slightly tweaked to run
+// in-browser.
+
+// Do NOT do this in a real application!
+
+// Normally, you would send the client token to YOUR backend, and use one of
+// our server SDKs to attach or verify it.
+//
+// Since this demo doesn't have a backend, it's directly returning what the
+// SnapAuth API returned so it can be displayed.
+
+class FakeBackendApi {
+
+  private authHeader: string
+  private host: URL
+
+  constructor(secretKey: string) {
+    this.authHeader = 'Basic ' + btoa(':' + secretKey)
+    this.host = new URL('https://api.snapauth.app')
+  }
+
+  // As a fake backend, this uses the user-provided value for the username
+  // and no handle. Normally, the `id` would be a generated value (primary
+  // key, etc) and the `handle` would be a username, email address, or
+  // similar user-provided identifier.
+  attachRegistration = async (token: string, userId: string): Promise<ApiInfo> => {
+    return await this.post('/registration/attach', { token, user: { id: userId } })
+  }
+
+  signIn = async (token: string): Promise<ApiInfo> => {
+    return await this.post('/auth/verify', { token })
+  }
+
+  private post = async (path: string, requestBody: unknown): Promise<ApiInfo> => {
+    try {
+      const response = await fetch(new URL(path, this.host), {
+        method: 'POST',
+        headers: {
+          Authorization: this.authHeader,
+          Accept: 'application/json',
+          'Content-type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      })
+      const responseBody = await response.json()
+      return {
+        requestBody,
+        responseBody,
+      }
+    } catch (error) {
+      return {
+        requestBody,
+        responseBody: {
+          error: true,
+          message: (error as Error).message,
+        }
+      }
+    }
+  }
+}
+
+export interface ApiInfo {
+  requestBody: unknown
+  responseBody: unknown
+}
+
+const backend = new FakeBackendApi(import.meta.env.VITE_SNAPAUTH_SECRET_KEY_NEVER_PUBLISH_THIS_IN_A_REAL_APP)
+export default backend

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,1 +1,2 @@
+export { default as backend } from './backend'
 export { default as toast } from './toast'

--- a/src/panels/Register.tsx
+++ b/src/panels/Register.tsx
@@ -17,6 +17,8 @@ const Register: React.FC = () => {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setBackendData(undefined)
+    setRegisterResponse(undefined)
 
     const name = username.current!.value
 

--- a/src/panels/Register.tsx
+++ b/src/panels/Register.tsx
@@ -29,7 +29,7 @@ const Register: React.FC = () => {
     if (registration.ok) {
       toast.success('Got a SnapAuth token')
 
-      const data = await backend.attachRegistration(registration.data.token, name)
+      const data = await backend.register(registration.data.token, name)
       // Again, for display purposes only.
       setBackendData(data)
     } else {

--- a/src/panels/Register.tsx
+++ b/src/panels/Register.tsx
@@ -1,8 +1,8 @@
 import { useRef, useState } from 'react'
-import { Button, Callout, Code, FormGroup, InputGroup, Section, SectionCard } from '@blueprintjs/core'
+import { Button, Callout, Code, FormGroup, InputGroup } from '@blueprintjs/core'
 import { SDK, RegisterResponse } from '@snapauth/sdk'
 
-import { SourceUrl } from 'components'
+import { ApiData, SourceUrl } from 'components'
 import { backend, toast } from 'helpers'
 
 import type { ApiInfo } from 'helpers/backend'
@@ -62,22 +62,7 @@ const Register: React.FC = () => {
       </FormGroup>
       <Button type="submit" intent="primary">Register</Button>
     </form>
-    {registerResponse && <Section title="Client SDK Response">
-      <output>
-        <pre>{JSON.stringify(registerResponse, undefined, 2)}</pre>
-      </output>
-    </Section>}
-    {backendData && <Section title="Backend">
-      <SectionCard>
-        <p><Code>POST /registration/attach</Code></p>
-        <output><pre>{JSON.stringify(backendData.requestBody, undefined, 2)}</pre></output>
-      </SectionCard>
-
-      <SectionCard>
-        <p>Response</p>
-        <output><pre>{JSON.stringify(backendData.responseBody, undefined, 2)}</pre></output>
-      </SectionCard>
-    </Section>}
+    <ApiData backendData={backendData} clientResponse={registerResponse} />
   </>
 }
 

--- a/src/panels/SignIn.tsx
+++ b/src/panels/SignIn.tsx
@@ -24,9 +24,9 @@ const SignIn: React.FC = () => {
     setAuthResponse(auth)
 
     if (auth.ok) {
+      toast.success('Got a SnapAuth token')
       const data = await backend.signIn(auth.data.token)
       setBackendData(data)
-      toast.success('Signed in')
     } else {
       toast.error(auth.error)
     }
@@ -35,7 +35,7 @@ const SignIn: React.FC = () => {
   return <>
     <Callout>
       <p>If you want a passkey-first auth flow or have a multi-step process, <Code>snapAuth.startAuth()</Code> is the way to go.
-      If not many of your users have passkeys yet, this alone can be a little jarring.</p>
+        If not many of your users have passkeys yet, this alone can be a little jarring.</p>
       <p>This is <em>great</em> way to re-authenticate a returning user, since you should already have their <Code>user id</Code> in a cookie or session.</p>
       <p><SourceUrl path="src/panels/SignIn.tsx" /></p>
     </Callout>
@@ -50,7 +50,7 @@ const SignIn: React.FC = () => {
       <Button type="submit" intent="primary">Sign In</Button>
     </form>
     <ApiData backendData={backendData} clientResponse={authResponse} />
-    </>
+  </>
 }
 
 export default SignIn

--- a/src/panels/SignIn.tsx
+++ b/src/panels/SignIn.tsx
@@ -2,7 +2,10 @@ import { useRef, useState } from 'react'
 import { Button, Callout, Code, FormGroup, InputGroup } from '@blueprintjs/core'
 import { SDK, AuthResponse } from '@snapauth/sdk'
 
-import { SourceUrl } from 'components'
+import { ApiData, SourceUrl } from 'components'
+import { backend, toast } from 'helpers'
+
+import type { ApiInfo } from 'helpers/backend'
 
 const snapAuth = new SDK(import.meta.env.VITE_SNAPAUTH_PUBLISHABLE_KEY)
 
@@ -10,12 +13,23 @@ const SignIn: React.FC = () => {
   const username = useRef<HTMLInputElement>(null)
 
   const [authResponse, setAuthResponse] = useState<AuthResponse>()
+  const [backendData, setBackendData] = useState<ApiInfo>()
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setAuthResponse(undefined)
+    setBackendData(undefined)
 
     const auth = await snapAuth.startAuth({ id: username.current!.value })
     setAuthResponse(auth)
+
+    if (auth.ok) {
+      const data = await backend.signIn(auth.data.token)
+      setBackendData(data)
+      toast.success('Signed in')
+    } else {
+      toast.error(auth.error)
+    }
   }
 
   return <>
@@ -35,9 +49,7 @@ const SignIn: React.FC = () => {
       </FormGroup>
       <Button type="submit" intent="primary">Sign In</Button>
     </form>
-    {authResponse &&
-    <output><pre>{JSON.stringify(authResponse, undefined, 2)}</pre></output>
-    }
+    <ApiData backendData={backendData} clientResponse={authResponse} />
     </>
 }
 


### PR DESCRIPTION
This adds some basic network calls to the demo so that it's more representative of a real app. They're now displayed alongside the client SDK data in order to provide more usage context.

>[!CAUTION]
> This is NOT the way SnapAuth is normally used - you should never make the server calls from client code. It will result in leaking secrets that can lead to account takeover. 

This doesn't _have_ an actual backend, and the demo app is being run on a dedicated domain with a dedicated SnapAuth account so there's nothing to compromise.
