### PR TITLE
Set up a build process so the demo can be deployed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.dockerignore
+.git
+node_modules
+dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 .git
 node_modules
 dist
+.github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+  # Build all PRs
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+# Help Dependabot checks run
+permissions:
+  checks: write
+  contents: read
+  packages: write
+  # Eventually support deployment tracking.
+  deployments: write
+
+jobs:
+  vite:
+    name: Vite/TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.build.outputs.server-tag }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Log in to docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build images
+        id: build
+        uses: firehed/multistage-docker-build-action@v1.7
+        with:
+          repository: ghcr.io/snapauthapp/demo-web
+          stages: node-dependencies
+          server-stage: server
+          parallel: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:21-alpine AS node-dependencies
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node-dependencies AS build
+COPY ./ ./
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:alpine AS server
+ENV PORT=8080
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+WORKDIR /var/www/html
+COPY --chown=nginx:nginx --from=build /app/dist ./
+

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,0 +1,26 @@
+# Nginx config template. See Dockerfile.
+server {
+    listen $PORT;
+
+    root /var/www/html;
+    index index.html;
+
+    location /robots.txt {
+        add_header Cache-Control 'no-store';
+        add_header Cache-Control 'no-cache';
+        expires 0;
+    }
+
+    location /assets {
+        add_header Cache-Control 'public';
+        expires 1m;
+    }
+
+    location / {
+        # Throw everything that doesn't match a static asset to index.html.
+        # That will run client-side routing.
+        try_files $uri /index.html;
+    }
+}
+
+# vim: ft=nginx


### PR DESCRIPTION
This is a simple "dump the contents of `npm run build` into a static asset server".

Eventually this might be better served by using github pages or something, but this fits easily into exiting infrastructure and is a known quantity.